### PR TITLE
Add hidden prop for line charts

### DIFF
--- a/src/components/chartjs-line.vue
+++ b/src/components/chartjs-line.vue
@@ -13,7 +13,11 @@ export default {
             type: Boolean,
             default: false,
         },
-        fill:{
+        fill: {
+            type: Boolean,
+            default: false,
+        },
+        hidden: {
             type: Boolean,
             default: false,
         },
@@ -73,6 +77,7 @@ export default {
                     pointHitRadius: 10,
                     data: this.data,
                     spanGaps: false,
+                    hidden: this.hidden,
                 }, ],
             },
         };


### PR DESCRIPTION
Hey there,

This PR adds a prop for marking a dataset as hidden in a line chart. 